### PR TITLE
Re-fixed wrapper order 

### DIFF
--- a/apphelpers/__init__.py
+++ b/apphelpers/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Scroll Tech"""
 __email__ = 'tech@scroll.in'
-__version__ = '0.12.8'
+__version__ = '0.12.9'

--- a/apphelpers/db/peewee.py
+++ b/apphelpers/db/peewee.py
@@ -3,13 +3,18 @@ import datetime
 import logging
 import os
 
-from functools import wraps
 from enum import Enum
 
 from peewee import Model, Field
 from playhouse.pool import PooledPostgresqlExtDatabase
 from playhouse.shortcuts import model_to_dict
 from playhouse.postgres_ext import DateTimeTZField
+
+
+try:
+    from hug.decorators import wraps
+except ModuleNotFoundError:
+    from functools import wraps
 
 
 def set_peewee_debug():

--- a/apphelpers/rest/hug.py
+++ b/apphelpers/rest/hug.py
@@ -1,9 +1,9 @@
 import inspect
 from dataclasses import dataclass, asdict
-from functools import wraps
 from falcon import HTTPUnauthorized, HTTPForbidden, HTTPNotFound
 
 import hug
+from hug.decorators import wraps
 import hug.introspect as introspect
 
 from apphelpers.db.peewee import dbtransaction

--- a/apphelpers/rest/hug.py
+++ b/apphelpers/rest/hug.py
@@ -235,7 +235,7 @@ class APIFactory:
     def build(self, method, method_args, method_kw, f):
         print(f'{method_args[0]} [{method.__name__.upper()}] => {f.__module__}:{f.__name__}')
         m = method(*method_args, **method_kw)
-        return self.access_wrapper(self.db_tr_wrapper(raise_not_found_on_none(m(f))))
+        return m(self.access_wrapper(self.db_tr_wrapper(raise_not_found_on_none(f))))
         # NOTE: ^ wrapper ordering is important. access_wrapper needs request which
         # others don't. If access_wrapper comes late in the order it won't be passed
         # request parameter.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.8
+current_version = 0.12.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/scrolltech/apphelpers',
-    version='0.12.8',
+    version='0.12.9',
     zip_safe=False,
 )

--- a/tests/app/endpoints.py
+++ b/tests/app/endpoints.py
@@ -53,6 +53,10 @@ echo_multisite_groups.groups_required = [sitegroups.privileged.value]
 echo_multisite_groups.groups_forbidden = [sitegroups.forbidden.value]
 
 
+def process_request(request, body):
+    return {'body': body, 'headers': request.headers}
+
+
 def setup_routes(factory):
 
     factory.get('/echo/{word}')(echo)
@@ -70,6 +74,8 @@ def setup_routes(factory):
     factory.get('/sites/{site_id}/secure-echo/{word}')(secure_multisite_echo)
     factory.get('/sites/{site_id}/echo-groups')(echo_multisite_groups)
     factory.get('/sites/{site_id}/snakes/{name}')(get_secure_snake)
+
+    factory.post('/request-and-body')(process_request)
 
     # ar_handlers = (None, arlib.create, None, arlib.get, arlib.update, None)
     # factory.map_resource('/resttest/', handlers=ar_handlers)

--- a/tests/app/endpoints.py
+++ b/tests/app/endpoints.py
@@ -57,6 +57,11 @@ def process_request(request, body):
     return {'body': body, 'headers': request.headers}
 
 
+def process_raw_request(request):
+    return {'raw_body': request.stream.read().decode(), 'headers': request.headers}
+process_raw_request.not_found_on_none = True
+
+
 def setup_routes(factory):
 
     factory.get('/echo/{word}')(echo)
@@ -76,6 +81,7 @@ def setup_routes(factory):
     factory.get('/sites/{site_id}/snakes/{name}')(get_secure_snake)
 
     factory.post('/request-and-body')(process_request)
+    factory.post('/request-raw-body', parse_body=False)(process_raw_request)
 
     # ar_handlers = (None, arlib.create, None, arlib.get, arlib.update, None)
     # factory.map_resource('/resttest/', handlers=ar_handlers)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -193,7 +193,7 @@ def test_site_group_access():
 
 
 def test_request_access():
-    url = urls.base + '/request-and-body'
+    url = urls.base + 'request-and-body'
     req = requests.post(url, data={'z': 1}, headers={'testheader': 'testheader-value'})
     resp = req.json()
     assert 'testheader'.upper() in resp['headers']
@@ -201,7 +201,7 @@ def test_request_access():
 
 
 def test_raw_request():
-    url = urls.base + '/request-raw-body'
+    url = urls.base + 'request-raw-body'
     req = requests.post(url, data={'z': 1}, headers={'testheader': 'testheader-value'})
     resp = req.json()
     assert 'testheader'.upper() in resp['headers']

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -190,3 +190,11 @@ def test_site_group_access():
 
     headers = {'Authorization': sid}
     assert requests.get(url, headers=headers).status_code == 200
+
+
+def test_request_access():
+    url = urls.base + '/request-and-body'
+    req = requests.post(url, data={'z': 1}, headers={'testheader': 'testheader-value'})
+    resp = req.json()
+    assert 'testheader'.upper() in resp['headers']
+    assert resp['body'] == {'z': '1'}

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -198,3 +198,10 @@ def test_request_access():
     resp = req.json()
     assert 'testheader'.upper() in resp['headers']
     assert resp['body'] == {'z': '1'}
+
+
+def test_raw_request():
+    url = urls.base + '/request-raw-body'
+    req = requests.post(url, data={'z': 1}, headers={'testheader': 'testheader-value'})
+    resp = req.json()
+    assert 'testheader'.upper() in resp['headers']


### PR DESCRIPTION
Re-fixed wrapper order to ensure the innermost wrapped function always has access to request and body